### PR TITLE
Add Streamlit volatility forecasting app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Intraday Volatility Forecasting App
+
+Streamlit app to forecast short-horizon realized volatility in 10-minute windows from limit order book data.
+
+## Features
+- Reconstruct 600-second windows with forward-filled snapshots.
+- Aggregate into 20 × 30-second buckets.
+- AR+GARCH (log-vol), HAR-style, and linear models.
+- Metrics: MSE and QLIKE.
+- Interactive charts for in-sample and future forecasts.
+
+## Installation
+
+```bash
+python -m venv venv
+source venv/bin/activate       # on Windows: venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+## Running the app
+
+```bash
+streamlit run app.py
+```
+
+## Expected CSV schema
+Columns (all required):
+
+| column          | description                                   |
+|-----------------|-----------------------------------------------|
+| `stock_id`      | integer stock identifier                      |
+| `time_id`       | integer window identifier                     |
+| `seconds_in_bucket` | 1..600 seconds inside the window        |
+| `WAP`           | weighted average price                        |
+| `BidAskSpread`  | bid-ask spread                                |
+| `bid_size1` / `ask_size1` / `bid_size2` / `ask_size2` | level sizes |
+
+RData files should contain a DataFrame with the same columns.
+
+## Notes
+The AG model uses log-realized-volatility with an AR(p) mean and GARCH(p, q) variance via the `arch` package, serving as a practical analogue to ARMA-GARCH.
+
+Run the app and explore different model settings and forecast horizons interactively.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,193 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+
+from src.data import load_csv, try_load_rdata
+from src.features import (
+    compute_log_returns,
+    bucketize_30s,
+    aggregate_buckets,
+    add_lags_and_rolls,
+)
+from src.models.garch_ag import AGConfig, AR_GARCH_VolModel
+from src.models.hav import HAVConfig, HAVModel
+from src.models.linear import LinearConfig, LinearVolModel
+from src.metrics import summarize_metrics
+from src.plotting import plot_insample, plot_future
+
+
+st.set_page_config(page_title="Intraday Volatility Forecasting", layout="wide")
+
+
+def generate_synthetic() -> pd.DataFrame:
+    """Generate a small synthetic dataset for demo purposes."""
+    seconds = np.arange(1, 601)
+    wap = 100 + np.cumsum(np.random.normal(0, 0.1, size=600))
+    bas = np.abs(np.random.normal(0, 0.01, size=600)) + 0.01
+    size1 = np.random.randint(1, 10, size=600)
+    size2 = np.random.randint(1, 10, size=600)
+    df = pd.DataFrame(
+        {
+            "stock_id": 0,
+            "time_id": 0,
+            "seconds_in_bucket": seconds,
+            "WAP": wap,
+            "BidAskSpread": bas,
+            "bid_size1": size1,
+            "ask_size1": size1,
+            "bid_size2": size2,
+            "ask_size2": size2,
+        }
+    )
+    return df
+
+
+def load_data(path: str) -> pd.DataFrame:
+    """Load CSV or RData depending on file extension."""
+    if path.lower().endswith(".csv"):
+        return load_csv(path)
+    if path.lower().endswith((".rdata", ".rda")):
+        return try_load_rdata(path)
+    raise ValueError("File must be .csv, .rdata, or .rda")
+
+
+# Sidebar: data loading
+st.sidebar.header("Data Loader")
+data_path = st.sidebar.text_input("CSV or RData path")
+load_button = st.sidebar.button("Load data")
+demo_button = st.sidebar.button("Generate synthetic demo data")
+
+if "data" not in st.session_state:
+    st.session_state["data"] = None
+
+if load_button:
+    try:
+        st.session_state["data"] = load_data(data_path)
+        st.success("Data loaded successfully.")
+    except Exception as exc:
+        st.session_state["data"] = None
+        st.error(f"Failed to load data: {exc}")
+
+if demo_button:
+    st.session_state["data"] = generate_synthetic()
+    st.success("Synthetic demo data generated.")
+
+data = st.session_state["data"]
+
+if data is not None:
+    # Sidebar: selections
+    st.sidebar.header("Window Selection")
+    stock_ids = sorted(data["stock_id"].unique())
+    stock_id = st.sidebar.selectbox("Stock ID", stock_ids)
+    time_ids = sorted(data[data["stock_id"] == stock_id]["time_id"].unique())
+    time_id = st.sidebar.selectbox("Time ID", time_ids)
+
+    # Sidebar: model controls
+    st.sidebar.header("Models")
+    ar_order = st.sidebar.number_input("AG AR order", min_value=0, max_value=5, value=1)
+    garch_p = st.sidebar.number_input("GARCH p", min_value=1, max_value=5, value=1)
+    garch_q = st.sidebar.number_input("GARCH q", min_value=1, max_value=5, value=1)
+
+    hav_use_bas = st.sidebar.checkbox("HAV include BAS lags", value=False)
+    lin_use_order = st.sidebar.checkbox("Linear include order", value=True)
+    lin_use_bas = st.sidebar.checkbox("Linear include BAS", value=True)
+
+    horizon = st.sidebar.number_input("Forecast horizon", 1, 40, 5)
+
+    # Filter selected window
+    window_df = data[(data["stock_id"] == stock_id) & (data["time_id"] == time_id)]
+    if window_df.empty:
+        st.error("No data for selected stock_id/time_id.")
+        st.stop()
+
+    # Feature pipeline
+    try:
+        df = compute_log_returns(window_df)
+        df = bucketize_30s(df)
+        bucket_df = aggregate_buckets(df)
+        bucket_df = add_lags_and_rolls(bucket_df, include_bas=True)
+    except Exception as exc:
+        st.error(f"Feature processing error: {exc}")
+        st.stop()
+
+    # Fit models
+    bucket_df["AG"] = np.nan
+    bucket_df["HAV"] = np.nan
+    bucket_df["Linear"] = np.nan
+
+    # AG Model
+    try:
+        ag_model = AR_GARCH_VolModel(AGConfig(ar_order, garch_p, garch_q))
+        ag_model.fit(bucket_df["realized_vol"])
+        bucket_df["AG"] = ag_model.predict_insample()
+        ag_forecast = ag_model.forecast(int(horizon))
+    except Exception as exc:
+        st.error(f"AG model failed: {exc}")
+        ag_forecast = np.array([np.nan] * int(horizon))
+
+    # HAV Model
+    try:
+        hav_model = HAVModel(HAVConfig(use_bas=hav_use_bas))
+        hav_model.fit(bucket_df)
+        bucket_df["HAV"] = hav_model.predict_insample(bucket_df)
+        hav_forecast = hav_model.forecast(bucket_df, int(horizon))
+    except Exception as exc:
+        st.error(f"HAV model failed: {exc}")
+        hav_forecast = np.array([np.nan] * int(horizon))
+
+    # Linear Model
+    try:
+        lin_model = LinearVolModel(
+            LinearConfig(
+                use_order_mean=lin_use_order, use_bas_mean=lin_use_bas
+            )
+        )
+        lin_model.fit(bucket_df)
+        bucket_df["Linear"] = lin_model.predict_insample(bucket_df)
+        lin_forecast = lin_model.forecast(bucket_df, int(horizon))
+    except Exception as exc:
+        st.error(f"Linear model failed: {exc}")
+        lin_forecast = np.array([np.nan] * int(horizon))
+
+    # Data preview
+    st.subheader("Bucketed Data")
+    st.dataframe(bucket_df)
+
+    # In-sample plot
+    st.subheader("In-sample Predictions")
+    insample_fig = plot_insample(
+        bucket_df,
+        truth_col="realized_vol",
+        ag_col="AG",
+        hav_col="HAV",
+        lr_col="Linear",
+        title=f"Stock {stock_id}, Time {time_id}",
+    )
+    st.plotly_chart(insample_fig, use_container_width=True)
+
+    # Metrics
+    st.subheader("Metrics")
+    metrics_df = summarize_metrics(
+        bucket_df,
+        truth_col="realized_vol",
+        pred_cols={"AG": "AG", "HAV": "HAV", "Linear": "Linear"},
+    )
+    metrics_df["MSE"] = metrics_df["MSE"].round(6)
+    metrics_df["QLIKE"] = metrics_df["QLIKE"].round(6)
+    st.table(metrics_df)
+
+    # Future forecast plot
+    st.subheader("Future Forecast")
+    future_fig = plot_future(
+        int(horizon),
+        ag_forecast,
+        hav_forecast,
+        lin_forecast,
+        f"{horizon}-step Ahead Forecast",
+    )
+    st.plotly_chart(future_fig, use_container_width=True)
+
+else:
+    st.info(
+        "Load a dataset using the sidebar. You may also generate synthetic demo data."
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+streamlit
+pandas
+numpy
+plotly
+scikit-learn
+arch
+statsmodels
+pyyaml
+pyreadr

--- a/src/data.py
+++ b/src/data.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import List
+import pandas as pd
+import pyreadr
+
+REQUIRED_COLS: List[str] = [
+    "stock_id",
+    "time_id",
+    "seconds_in_bucket",
+    "WAP",
+    "BidAskSpread",
+    "bid_size1",
+    "ask_size1",
+    "bid_size2",
+    "ask_size2",
+]
+
+
+def _validate_columns(df: pd.DataFrame) -> pd.DataFrame:
+    missing = set(REQUIRED_COLS) - set(df.columns)
+    if missing:
+        raise ValueError(f"Missing columns: {missing}")
+    return df[REQUIRED_COLS].copy()
+
+
+def _coerce_and_sort(df: pd.DataFrame) -> pd.DataFrame:
+    df["stock_id"] = df["stock_id"].astype(int)
+    df["time_id"] = df["time_id"].astype(int)
+    df["seconds_in_bucket"] = df["seconds_in_bucket"].astype(int)
+    numeric_cols = [
+        "WAP",
+        "BidAskSpread",
+        "bid_size1",
+        "ask_size1",
+        "bid_size2",
+        "ask_size2",
+    ]
+    for col in numeric_cols:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    df.sort_values(["stock_id", "time_id", "seconds_in_bucket"], inplace=True)
+    df.reset_index(drop=True, inplace=True)
+    return df
+
+
+def load_csv(path: str) -> pd.DataFrame:
+    """Load and validate CSV data."""
+    df = pd.read_csv(path)
+    df = _validate_columns(df)
+    df = _coerce_and_sort(df)
+    return df
+
+
+def try_load_rdata(path: str) -> pd.DataFrame:
+    """Load and validate RData using pyreadr."""
+    result = pyreadr.read_r(path)
+    if len(result) == 0:
+        raise ValueError("No objects found in RData file.")
+    df = None
+    for obj in result.values():
+        if isinstance(obj, pd.DataFrame):
+            df = obj
+            break
+    if df is None:
+        raise ValueError("No DataFrame object in RData file.")
+    df = _validate_columns(df)
+    df = _coerce_and_sort(df)
+    return df

--- a/src/features.py
+++ b/src/features.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def compute_log_returns(df: pd.DataFrame) -> pd.DataFrame:
+    """Reindex seconds to 1..600, forward-fill, and compute log returns."""
+    numeric_cols = [
+        "WAP",
+        "BidAskSpread",
+        "bid_size1",
+        "ask_size1",
+        "bid_size2",
+        "ask_size2",
+    ]
+    group_cols = ["stock_id", "time_id"]
+
+    def _process(group: pd.DataFrame) -> pd.DataFrame:
+        group = group.set_index("seconds_in_bucket").reindex(range(1, 601))
+        group[group_cols[0]] = group[group_cols[0]].iloc[0]
+        group[group_cols[1]] = group[group_cols[1]].iloc[0]
+        group[numeric_cols] = group[numeric_cols].ffill().bfill()
+        group["log_return"] = np.log(group["WAP"]).diff().fillna(0.0)
+        group.reset_index(inplace=True)
+        group.rename(columns={"index": "seconds_in_bucket"}, inplace=True)
+        return group
+
+    return df.groupby(group_cols, group_keys=False).apply(_process)
+
+
+def bucketize_30s(df: pd.DataFrame) -> pd.DataFrame:
+    """Assign 30-second buckets and compute order flow."""
+    df = df.copy()
+    df["time_bucket"] = ((df["seconds_in_bucket"] - 1) // 30) + 1
+    df["order_flow"] = (
+        df["bid_size1"] + df["ask_size1"] + df["bid_size2"] + df["ask_size2"]
+    )
+    return df
+
+
+def aggregate_buckets(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate seconds to 30-second buckets."""
+    agg = (
+        df.groupby(["stock_id", "time_id", "time_bucket"])
+        .agg(
+            realized_vol=("log_return", lambda x: np.sqrt(np.sum(np.square(x)))),
+            price=("WAP", "mean"),
+            BidAskSpread=("BidAskSpread", "mean"),
+            order=("order_flow", "mean"),
+        )
+        .reset_index()
+    )
+    return agg
+
+
+def add_lags_and_rolls(bucket_df: pd.DataFrame, include_bas: bool = True) -> pd.DataFrame:
+    """Add lagged and rolling features for HAV model."""
+    df = bucket_df.copy()
+    group_cols = ["stock_id", "time_id"]
+
+    df["previous_volatility"] = df.groupby(group_cols)["realized_vol"].shift(1)
+    df["mean_prev_5_vol"] = (
+        df.groupby(group_cols)["realized_vol"]
+        .apply(lambda s: s.shift(1).rolling(5, min_periods=1).mean())
+        .reset_index(level=[0, 1], drop=True)
+    )
+
+    if include_bas:
+        df["previous_BidAskSpread"] = df.groupby(group_cols)["BidAskSpread"].shift(1)
+        df["mean_prev_5_bas"] = (
+            df.groupby(group_cols)["BidAskSpread"]
+            .apply(lambda s: s.shift(1).rolling(5, min_periods=1).mean())
+            .reset_index(level=[0, 1], drop=True)
+        )
+    return df

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Dict
+import numpy as np
+import pandas as pd
+
+
+def mse(y_true: pd.Series, y_pred: pd.Series) -> float:
+    """Mean squared error."""
+    return float(np.mean((y_true - y_pred) ** 2))
+
+
+def qlike(y_true: pd.Series, y_pred: pd.Series, eps: float = 1e-12) -> float:
+    """QLIKE on variances."""
+    true_var = np.square(y_true)
+    pred_var = np.square(y_pred)
+    return float(np.mean(np.log(pred_var + eps) + true_var / (pred_var + eps)))
+
+
+def summarize_metrics(
+    df: pd.DataFrame, truth_col: str, pred_cols: Dict[str, str]
+) -> pd.DataFrame:
+    """Summarize metrics for multiple prediction columns."""
+    records = []
+    for name, col in pred_cols.items():
+        mask = df[col].notna()
+        if mask.any():
+            y_true = df.loc[mask, truth_col]
+            y_pred = df.loc[mask, col]
+            records.append(
+                {"model": name, "MSE": mse(y_true, y_pred), "QLIKE": qlike(y_true, y_pred)}
+            )
+    return pd.DataFrame.from_records(records)

--- a/src/models/garch_ag.py
+++ b/src/models/garch_ag.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+import pandas as pd
+from arch import arch_model
+
+
+@dataclass
+class AGConfig:
+    ar_order: int
+    garch_p: int
+    garch_q: int
+
+
+class AR_GARCH_VolModel:
+    """AR-GARCH model on log-volatility."""
+
+    def __init__(self, config: AGConfig, epsilon: float = 1e-8):
+        self.config = config
+        self.epsilon = epsilon
+        self.model = None
+        self.result = None
+
+    def fit(self, vol_series: pd.Series) -> "AR_GARCH_VolModel":
+        y = np.log(vol_series + self.epsilon)
+        am = arch_model(
+            y,
+            mean="AR",
+            lags=self.config.ar_order,
+            vol="GARCH",
+            p=self.config.garch_p,
+            q=self.config.garch_q,
+            rescale=False,
+        )
+        self.result = am.fit(disp="off")
+        self.model = am
+        return self
+
+    def predict_insample(self) -> pd.Series:
+        if self.result is None:
+            raise ValueError("Model is not fitted.")
+        forecast = self.result.forecast(horizon=1, reindex=True)
+        nobs = self.result.model.nobs
+        mean_series = forecast.mean["h.1"].iloc[:nobs]
+        return np.exp(mean_series)
+
+    def forecast(self, horizon: int) -> np.ndarray:
+        if self.result is None:
+            raise ValueError("Model is not fitted.")
+        forecast = self.result.forecast(horizon=horizon, reindex=True)
+        mean_forecast = forecast.mean.iloc[-1].values
+        return np.exp(mean_forecast)

--- a/src/models/hav.py
+++ b/src/models/hav.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+
+
+@dataclass
+class HAVConfig:
+    use_bas: bool = False
+
+
+class HAVModel:
+    """HAR-style linear regression model."""
+
+    def __init__(self, config: HAVConfig):
+        self.config = config
+        self.reg = LinearRegression()
+
+    def _feature_cols(self) -> list:
+        cols = ["previous_volatility", "mean_prev_5_vol"]
+        if self.config.use_bas:
+            cols.extend(["previous_BidAskSpread", "mean_prev_5_bas"])
+        return cols
+
+    def fit(self, df: pd.DataFrame) -> "HAVModel":
+        cols = self._feature_cols()
+        train_df = df.dropna(subset=cols + ["realized_vol"])
+        if train_df.empty:
+            raise ValueError("Not enough data to fit HAV model.")
+        self.reg.fit(train_df[cols], train_df["realized_vol"])
+        return self
+
+    def predict_insample(self, df: pd.DataFrame) -> pd.Series:
+        cols = self._feature_cols()
+        mask = df[cols].notna().all(axis=1)
+        preds = pd.Series(index=df.index, dtype=float)
+        if mask.any():
+            preds.loc[mask] = self.reg.predict(df.loc[mask, cols])
+        return preds
+
+    def forecast(self, df: pd.DataFrame, horizon: int) -> np.ndarray:
+        cols = self._feature_cols()
+        vols = df["realized_vol"].tolist()
+        bas_value = df["BidAskSpread"].iloc[-1] if self.config.use_bas else None
+        preds = []
+        for _ in range(horizon):
+            prev = vols[-1]
+            mean5 = np.mean(vols[-5:])
+            features = [prev, mean5]
+            if self.config.use_bas:
+                features.extend([bas_value, bas_value])
+            pred = self.reg.predict([features])[0]
+            preds.append(pred)
+            vols.append(pred)
+        return np.array(preds)

--- a/src/models/linear.py
+++ b/src/models/linear.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+
+
+@dataclass
+class LinearConfig:
+    use_order_mean: bool = True
+    use_bas_mean: bool = True
+
+
+class LinearVolModel:
+    """Linear regression on exogenous features."""
+
+    def __init__(self, config: LinearConfig):
+        self.config = config
+        self.reg = LinearRegression()
+        self.feature_cols = self._feature_cols()
+
+    def _feature_cols(self) -> list:
+        cols = ["price"]
+        if self.config.use_order_mean:
+            cols.append("order")
+        if self.config.use_bas_mean:
+            cols.append("BidAskSpread")
+        return cols
+
+    def fit(self, df: pd.DataFrame) -> "LinearVolModel":
+        train_df = df.dropna(subset=self.feature_cols + ["realized_vol"])
+        if train_df.empty:
+            raise ValueError("Not enough data to fit Linear model.")
+        self.reg.fit(train_df[self.feature_cols], train_df["realized_vol"])
+        return self
+
+    def predict_insample(self, df: pd.DataFrame) -> pd.Series:
+        mask = df[self.feature_cols].notna().all(axis=1)
+        preds = pd.Series(index=df.index, dtype=float)
+        if mask.any():
+            preds.loc[mask] = self.reg.predict(df.loc[mask, self.feature_cols])
+        return preds
+
+    def forecast(self, df: pd.DataFrame, horizon: int) -> np.ndarray:
+        last_row = df.iloc[-1][self.feature_cols].values.reshape(1, -1)
+        pred = self.reg.predict(last_row)[0]
+        return np.repeat(pred, horizon)

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+
+def plot_insample(
+    df: pd.DataFrame,
+    truth_col: str,
+    ag_col: str,
+    hav_col: str,
+    lr_col: str,
+    title: str,
+) -> go.Figure:
+    """Overlay in-sample predictions with truth."""
+    fig = go.Figure()
+    x = df["time_bucket"]
+    fig.add_trace(go.Scatter(x=x, y=df[truth_col], name="True", mode="lines+markers"))
+    if ag_col in df:
+        fig.add_trace(go.Scatter(x=x, y=df[ag_col], name="AG", mode="lines"))
+    if hav_col in df:
+        fig.add_trace(go.Scatter(x=x, y=df[hav_col], name="HAV", mode="lines"))
+    if lr_col in df:
+        fig.add_trace(go.Scatter(x=x, y=df[lr_col], name="Linear", mode="lines"))
+    fig.update_layout(title=title, xaxis_title="Time Bucket", yaxis_title="Volatility")
+    return fig
+
+
+def plot_future(
+    horizon: int, ag: np.ndarray, hav: np.ndarray, lr: np.ndarray, title: str
+) -> go.Figure:
+    """Plot future forecasts."""
+    x = list(range(1, horizon + 1))
+    fig = go.Figure()
+    if ag is not None:
+        fig.add_trace(go.Scatter(x=x, y=ag, name="AG", mode="lines+markers"))
+    if hav is not None:
+        fig.add_trace(go.Scatter(x=x, y=hav, name="HAV", mode="lines+markers"))
+    if lr is not None:
+        fig.add_trace(go.Scatter(x=x, y=lr, name="Linear", mode="lines+markers"))
+    fig.update_layout(title=title, xaxis_title="Horizon", yaxis_title="Volatility")
+    return fig


### PR DESCRIPTION
## Summary
- Implement Streamlit app for intraday volatility forecasting with model controls and plots
- Add data loading, feature engineering, metrics, and plotting utilities
- Provide AR-GARCH, HAV, and linear models with forecasting

## Testing
- `python -m py_compile $(find . -name "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_68ac4e7fd1688324bea125e94e1ead8e